### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://office-test1.visualstudio.com/c333eda8-ed40-4ad1-89d7-48210895524e/986361a6-4d79-4ad7-acb3-16185c6b9cfd/_apis/work/boardbadge/5e1d3e29-49fb-4187-84ed-fe0c58580a47)](https://office-test1.visualstudio.com/c333eda8-ed40-4ad1-89d7-48210895524e/_boards/board/t/986361a6-4d79-4ad7-acb3-16185c6b9cfd/Microsoft.RequirementCategory)
 # TestingSampleRepo
 Just seeing what happens
 


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#18122](https://office-test1.visualstudio.com/c333eda8-ed40-4ad1-89d7-48210895524e/_workitems/edit/18122). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.